### PR TITLE
Fix problem with documents which only have one top-level header

### DIFF
--- a/lib/multipage-html5-converter.rb
+++ b/lib/multipage-html5-converter.rb
@@ -281,6 +281,7 @@ class MultipageHtml5Converter < Asciidoctor::Converter::Html5Converter
   def generate_outline(node, opts = {})
     # This is the same as Html5Converter outline()
     return unless node.sections?
+    return if node.sections.empty?
     sectnumlevels = opts[:sectnumlevels] || (node.document.attr 'sectnumlevels', 3).to_i
     toclevels = opts[:toclevels] || (node.document.attr 'toclevels', 2).to_i
     sections = node.sections


### PR DESCRIPTION
There seems to be a problem when a document has only one top-level heading and a TOC should be generated. Converting the following document:

```
:doctype: book
:toc: left

= Main header
Something something
```

produces the following error:

```
asciidoctor-extensions-lab/lib/multipage-html5-converter.rb:287:in `generate_outline': undefined method `level' for nil:NilClass (NoMethodError)
```

This also happens when using other doctypes than book, which have only one top-level heading by default.

The PR should fix the error.